### PR TITLE
Add WithDefaultLevel option to set the default log level

### DIFF
--- a/grpc/README.md
+++ b/grpc/README.md
@@ -80,7 +80,7 @@ func main() {
 		// We will use the sloggrpc.AppendToAttributesAll option, which is fairly verbose with the attributes.
 		// There is also a slimmer sloggrpc.AppendToAttributesDefault, which is what it used if no option is provided.
 		// You can also write your own to customize which attributes are added, or rename their keys.
-		// There are also other options available: WithErrorToLevel, and WithLogger
+		// There are also other options available: WithDefaultLevel, WithErrorToLevel, and WithLogger
 		grpc.ChainUnaryInterceptor(sloggrpc.SlogUnaryServerInterceptor(
 			sloggrpc.WithAppendToAttributes(sloggrpc.AppendToAttributesAll),
 			sloggrpc.WithInterceptorFilter(sloggrpc.InterceptorFilterIgnoreReflection))),

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -35,6 +35,7 @@ type config struct {
 	InterceptorFilter  InterceptorFilter
 	AppendToAttributes AppendToAttributes
 	ErrorToLevel       ErrorToLevel
+	DefaultLevel       slog.Level
 	role               string
 	Logger             Logger
 }
@@ -49,6 +50,7 @@ func newConfig(opts []Option, role string) *config {
 	c := &config{
 		AppendToAttributes: AppendToAttributesDefault,
 		Logger:             LoggerDefault,
+		DefaultLevel:       slog.LevelInfo,
 		role:               role,
 	}
 	if role == "client" {
@@ -217,4 +219,17 @@ func (o interceptorLoggerOption) apply(c *config) {
 	if o.f != nil {
 		c.Logger = o.f
 	}
+}
+
+// WithDefaultLevel returns an Option to set the log level for successful operations (requests, responses, etc.)
+func WithDefaultLevel(level slog.Level) Option {
+	return interceptorDefaultLevelOption{level: level}
+}
+
+type interceptorDefaultLevelOption struct {
+	level slog.Level
+}
+
+func (o interceptorDefaultLevelOption) apply(c *config) {
+	c.DefaultLevel = o.level
 }

--- a/grpc/slogger.go
+++ b/grpc/slogger.go
@@ -20,7 +20,7 @@ func (c *config) appendCode(attrs []slog.Attr, err error) (slog.Level, []slog.At
 	}
 	attrs = c.AppendToAttributes(attrs, slog.String("code_name", codes.OK.String()))
 	attrs = c.AppendToAttributes(attrs, slog.Int("code", int(codes.OK)))
-	return slog.LevelInfo, attrs
+	return c.DefaultLevel, attrs
 }
 
 func (c *config) appendCommon(attrs []slog.Attr, role Role, call Call, peer Peer) []slog.Attr {
@@ -53,7 +53,7 @@ func (c *config) logRequest(ctx context.Context, role Role, call Call, peer Peer
 	attrs := c.appendCommon(make([]slog.Attr, 0, 10), role, call, peer)
 	attrs = c.appendPayload(attrs, "req", req)
 
-	c.Logger(ctx, slog.LevelInfo, "rpcReq", attrs...)
+	c.Logger(ctx, c.DefaultLevel, "rpcReq", attrs...)
 }
 
 func (c *config) logResponse(ctx context.Context, role Role, call Call, peer Peer, req Payload, resp Payload, result Result) {
@@ -70,7 +70,7 @@ func (c *config) logStreamStart(ctx context.Context, role Role, call Call, peer 
 		// No need to log the result code/payload, because if the server has
 		// received the start connection, it will always be good.
 		attrs := c.appendCommon(make([]slog.Attr, 0, 9), role, call, peer)
-		c.Logger(ctx, slog.LevelInfo, "rpcStreamStart", attrs...)
+		c.Logger(ctx, c.DefaultLevel, "rpcStreamStart", attrs...)
 		return
 	}
 


### PR DESCRIPTION
In high volume systems, the default log level of sloggrpc.SlogUnaryServerInterceptor might be too verbose. This option allows you to set the default log level to a more appropriate level, e.g. slog.LevelDebug.