### PR TITLE
feat: Propagate attributes to parent context

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"sync"
 	"time"
 
 	slogctx "github.com/veqryn/slog-context"
-	"github.com/veqryn/slog-context/internal/attr"
 )
 
 // AttrCollection is an http middleware that collects slog.Attr from
@@ -29,10 +27,9 @@ import (
 // slog.InfoContext).
 func AttrCollection(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// If the context already contains our map, we don't need to create a new one
-		if ctx := r.Context(); fromCtx(ctx) == nil {
-			r = r.WithContext(newCtx(ctx, newSyncOrderedMap()))
-		}
+		// Use the propagation initializer from the root package. It is a no-op
+		// if propagation was already initialized on the context.
+		r = r.WithContext(slogctx.InitPropagation(r.Context()))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -42,96 +39,15 @@ func AttrCollection(next http.Handler) http.Handler {
 // that is visible to all intermediate middlewares and functions between the
 // collector middleware and the call to With.
 func With(ctx context.Context, args ...any) context.Context {
-	// Convert args to a slice of slog.Attr
-	attrs := attr.ArgsToAttrSlice(args)
-	if len(attrs) == 0 {
-		return ctx
-	}
-
-	m := fromCtx(ctx)
-	if m == nil {
-		// Someone is using this package outside of a request.
-		// As a feature for utility methods that could be used both in requests
-		// and outside of requests, the most useful thing to do is to return the
-		// context with the attributes added. That way the attributes will still
-		// end up on log lines using this context, which is the goal in both cases.
-		return slogctx.With(ctx, args...)
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// For each attribute, if it is not already in the map, append it to the end
-	// of our ordered list. Then add/update it in the map.
-	for _, attr := range attrs {
-		if _, ok := m.kv[attr.Key]; !ok {
-			// Does not yet exist in the append-only ordered list
-			m.order = append(m.order, attr.Key)
-		}
-		m.kv[attr.Key] = attr
-	}
-	return ctx
+	// Delegate to the propagation-aware add function. It will fall back to
+	// the attached-logger flow when propagation isn't initialized.
+	return slogctx.AddWithPropagation(ctx, args...)
 }
 
 // ExtractAttrCollection is a slogctx Extractor that must be used with a
 // slogctx.Handler (via slogctx.HandlerOptions) as Prependers or Appenders.
 // It will cause the Handler to add the Attributes added by sloghttp.With to all
 // log lines using that same context.
-func ExtractAttrCollection(ctx context.Context, _ time.Time, _ slog.Level, _ string) []slog.Attr {
-	m := fromCtx(ctx)
-	if m == nil {
-		return nil
-	}
-
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	// Add the attributes, in the order defined
-	var attrs []slog.Attr
-	for _, key := range m.order {
-		attrs = append(attrs, m.kv[key])
-	}
-	return attrs
-}
-
-// syncOrderedMap is an append-only synchronized ordered map
-type syncOrderedMap struct {
-	mu    sync.RWMutex
-	kv    map[string]slog.Attr
-	order []string
-}
-
-// newSyncOrderedMap creates a usable initialized *syncOrderedMap
-func newSyncOrderedMap() *syncOrderedMap {
-	return &syncOrderedMap{
-		kv: map[string]slog.Attr{},
-	}
-}
-
-// ctxKey is how we find our attribute collector data structure in the context
-type ctxKey struct{}
-
-// newCtx returns a copy of the parent context with the collector data structure
-// attached. The parent context will be unaffected.
-func newCtx(parent context.Context, m *syncOrderedMap) context.Context {
-	if parent == nil {
-		parent = context.Background()
-	}
-
-	return context.WithValue(parent, ctxKey{}, m)
-}
-
-// fromCtx returns the collector data structure if it is found within the
-// context, or nil.
-func fromCtx(ctx context.Context) *syncOrderedMap {
-	if ctx == nil {
-		return nil
-	}
-
-	m := ctx.Value(ctxKey{})
-	if m == nil {
-		return nil
-	}
-
-	return m.(*syncOrderedMap)
+func ExtractAttrCollection(ctx context.Context, t time.Time, lvl slog.Level, msg string) []slog.Attr {
+	return slogctx.ExtractPropagatedAttrs(ctx, t, lvl, msg)
 }

--- a/propagation.go
+++ b/propagation.go
@@ -1,0 +1,113 @@
+package slogctx
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/veqryn/slog-context/internal/attr"
+)
+
+// InitPropagation initializes a context that allows propagating attributes from child context back to parents.
+// Essentially, it lets you collect slog attributes that are discovered later in
+// the stack (such as authentication and user ID's, derived values, attributes
+// only discovered halfway-through the final request handler after several db
+// queries, etc), and be able to have them be included in the log lines of other
+// middlewares (such as a middleware that logs all requests that come in).
+// For a ready-to-use http middleware that implements this feature, see package github.com/veqryn/slog-context/http
+func InitPropagation(parent context.Context) context.Context {
+	if fromCtx(parent) != nil {
+		// If we already have a collector in the context, return it
+		return parent
+	}
+
+	m := &syncOrderedMap{
+		kv: map[string]slog.Attr{},
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	return context.WithValue(parent, ctxKey{}, m)
+}
+
+// AddWithPropagation adds the provided attributes to the context and propagates them to parent contextes.
+// If propagation wasn't initialized on the context via a InitPropagation(), it falls back to performing a normal Add() operation.
+func AddWithPropagation(ctx context.Context, args ...any) context.Context {
+	// Convert args to a slice of slog.Attr
+	attrs := attr.ArgsToAttrSlice(args)
+	if len(attrs) == 0 {
+		return ctx
+	}
+
+	m := fromCtx(ctx)
+	if m == nil {
+		// Someone is using this package outside of a request.
+		// As a feature for utility methods that could be used both in requests
+		// and outside of requests, the most useful thing to do is to return the
+		// context with the attributes added. That way the attributes will still
+		// end up on log lines using this context if this use the attached logger flow
+		return With(ctx, args...)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// For each attribute, if it is not already in the map, append it to the end
+	// of our ordered list. Then add/update it in the map.
+	for _, attr := range attrs {
+		if _, ok := m.kv[attr.Key]; !ok {
+			// Does not yet exist in the append-only ordered list
+			m.order = append(m.order, attr.Key)
+		}
+		m.kv[attr.Key] = attr
+	}
+	return ctx
+}
+
+// ExtractPropagatedAttrs is a slogctx Extractor that must be used with a
+// slogctx.Handler (via slogctx.HandlerOptions) as Prependers or Appenders.
+// It will cause the Handler to add the Attributes added by slogctx.AddWithPropagation to all
+// log lines using that same context.
+func ExtractPropagatedAttrs(ctx context.Context, _ time.Time, _ slog.Level, _ string) []slog.Attr {
+	m := fromCtx(ctx)
+	if m == nil {
+		return nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Add the attributes, in the order defined
+	var attrs []slog.Attr
+	for _, key := range m.order {
+		attrs = append(attrs, m.kv[key])
+	}
+	return attrs
+}
+
+// syncOrderedMap is an append-only synchronized ordered map
+type syncOrderedMap struct {
+	mu    sync.RWMutex
+	kv    map[string]slog.Attr
+	order []string
+}
+
+// ctxKey is how we find our attribute collector data structure in the context
+type ctxKey struct{}
+
+// fromCtx returns the collector data structure if it is found within the
+// context, or nil.
+func fromCtx(ctx context.Context) *syncOrderedMap {
+	if ctx == nil {
+		return nil
+	}
+
+	m := ctx.Value(ctxKey{})
+	if m == nil {
+		return nil
+	}
+
+	return m.(*syncOrderedMap)
+}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -1,0 +1,199 @@
+package slogctx_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	slogctx "github.com/veqryn/slog-context"
+	"github.com/veqryn/slog-context/internal/test"
+)
+
+func TestAttrCollection(t *testing.T) {
+	// Create the *slogctx.Handler middleware
+	tester := &test.Handler{}
+	h := slogctx.NewHandler(
+		tester,
+		&slogctx.HandlerOptions{
+			Prependers: []slogctx.AttrExtractor{
+				slogctx.ExtractPropagatedAttrs, // our propagated attributes extractor
+				slogctx.ExtractPrepended,       // for all other prepended attributes
+			},
+		},
+	)
+	// Using slog.SetDefault in tests can be problematic,
+	// as the steps run in parallel and step on each other
+	l := slog.New(h)
+	ctx := context.Background()
+
+	httpHandler := middlewareWithInitPropagation(
+		httpLoggingMiddleware(l)(
+			http.HandlerFunc(helloUser(l)),
+		),
+	)
+
+	srv := httptest.NewUnstartedServer(httpHandler)
+	srv.Config.BaseContext = func(l net.Listener) context.Context {
+		return ctx
+	}
+	srv.Start()
+	defer srv.Close()
+
+	//t.Log(srv.URL)
+	resp, err := http.Get(srv.URL + "/?id=24680")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Expected status code of 200; Got: ", resp.StatusCode)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(respBody) != "Hello User #24680" {
+		t.Fatal("Response body incorrect: ", string(respBody))
+	}
+
+	jsn, err := tester.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{"time":"2023-09-29T13:00:59Z","level":"INFO","msg":"saying hello...","path":"/","id":"24680","foo":"bar"}
+{"time":"2023-09-29T13:00:59Z","level":"INFO","msg":"Response","path":"/","id":"24680","method":"GET"}
+`
+	if string(jsn) != expected {
+		t.Error("Incorrect logs received: ", string(jsn))
+	}
+}
+
+// TestOutsideRequestAttachedAttributes tests using AddWithPropagation without InitPropagation(),
+// while using the attached attributes flow.
+func TestOutsideRequestAttachedAttributes(t *testing.T) {
+	// Create the *slogctx.Handler middleware
+	tester := &test.Handler{}
+	h := slogctx.NewHandler(
+		tester,
+		&slogctx.HandlerOptions{
+			Prependers: []slogctx.AttrExtractor{
+				slogctx.ExtractPropagatedAttrs, // our propagated attributes extractor
+				slogctx.ExtractPrepended,       // for all other prepended attributes
+			},
+		},
+	)
+	ctx := context.Background()
+	l := slog.New(h)
+
+	ctx = slogctx.AddWithPropagation(ctx, "id", "13579")
+	ctx = slogctx.AddWithPropagation(ctx) // Should be ignored
+
+	// "id" will be missing since we didn't use InitPropagation()
+	l.InfoContext(ctx, "utility method")
+
+	jsn, err := tester.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{"time":"2023-09-29T13:00:59Z","level":"INFO","msg":"utility method"}
+`
+	if string(jsn) != expected {
+		t.Error("Incorrect logs received: ", string(jsn))
+	}
+}
+
+// TestOutsideRequestAttachedLogger tests using AddWithPropagation without InitPropagation(),
+// while using the attached logger flow.
+func TestOutsideRequestAttachedLogger(t *testing.T) {
+	// Create the *slogctx.Handler middleware
+	tester := &test.Handler{}
+	h := slogctx.NewHandler(
+		tester,
+		&slogctx.HandlerOptions{
+			Prependers: []slogctx.AttrExtractor{
+				slogctx.ExtractPropagatedAttrs, // our propagated attributes extractor
+				slogctx.ExtractPrepended,       // for all other prepended attributes
+			},
+		},
+	)
+	ctx := context.Background()
+	l := slog.New(h)
+	ctx = slogctx.NewCtx(ctx, l)
+
+	ctx = slogctx.AddWithPropagation(ctx, "id", "13579")
+	ctx = slogctx.AddWithPropagation(ctx) // Should be ignored
+
+	// "id" will be present. We didn't use InitPropagation(), however AddWithPropagation() falls back to the attached logger flow
+	slogctx.FromCtx(ctx).InfoContext(ctx, "utility method")
+
+	jsn, err := tester.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{"time":"2023-09-29T13:00:59Z","level":"INFO","msg":"utility method","id":"13579"}
+`
+
+	if string(jsn) != expected {
+		t.Error("Incorrect logs received: ", string(jsn))
+	}
+}
+
+// This is a stand-in for a middleware that might be capturing and logging out
+// things like the response code, request body, response body, url, method, etc.
+// It doesn't have access to any of the new context's created within the next handler.
+// But it should still log with any of the attributes added through AddWithPropagation()
+func httpLoggingMiddleware(l *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Add some logging context/baggage before the handler
+			r = r.WithContext(slogctx.AddWithPropagation(r.Context(), "path", r.URL.Path))
+
+			// Call the next handler
+			next.ServeHTTP(w, r)
+
+			// Log out that we had a response
+			l.InfoContext(r.Context(), "Response", "method", r.Method) // should also have both "path" and "id", but not "foo"
+		})
+	}
+}
+
+// This is a stand-in for an api endpoint
+func helloUser(l *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Stand-in for a User ID.
+		// Add it to our middleware's map
+		id := r.URL.Query().Get("id")
+
+		// slogctx.AddWithPropagation will add "id" to to the middleware, because it is a synchronized map.
+		// It will show up in all log calls up and down the stack, until the request in middlewareWithInitPropagation exits.
+		ctx := slogctx.AddWithPropagation(r.Context(), "id", id)
+
+		// slogctx.Prepend will add "foo" only to the Returned context, which will limits its scope
+		// to the rest of this function and any sub-functions called.
+		// The callers of helloUser and all the middlewares will not see "foo".
+		ctx = slogctx.Prepend(ctx, "foo", "bar")
+
+		// Log some things
+		l.InfoContext(ctx, "saying hello...") // should also have both "path", "id", and "foo"
+
+		// Respond
+		_, _ = w.Write([]byte("Hello User #" + id))
+	}
+}
+
+// middleware to initialize propagating attributes from child context back to parents for each request.
+func middlewareWithInitPropagation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(slogctx.InitPropagation(r.Context()))
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
Following discussion from https://github.com/veqryn/slog-context/issues/34
- Adds feature to propagate attributes to parent context
- Refactor the `sloghttp` sub package to use this feature

cc @veqryn 